### PR TITLE
Fixes a mixup between Consumption and Power services initialization

### DIFF
--- a/lib/DeconzAccessory/index.js
+++ b/lib/DeconzAccessory/index.js
@@ -164,12 +164,12 @@ class DeconzAccessory extends AccessoryDelegate {
     } else if (params.serviceName === 'Battery') {
       service = this.servicesByServiceName.Battery?.[0]
     } else if (params.serviceName === 'Consumption') {
-      service = this.servicesByServiceName.Power?.[0]
+      service = this.servicesByServiceName.Consumption?.[0]
       if (service != null) {
         service.addResource(resource)
       }
     } else if (params.serviceName === 'Power') {
-      service = this.servicesByServiceName.Consumption?.[0]
+      service = this.servicesByServiceName.Power?.[0]
       if (service != null) {
         service.addResource(resource)
       }


### PR DESCRIPTION
Fixes a mixup between Consumption and Power services initialization on Accessory index.js file to avoid SyntaxError: totalConsumption: duplicate key on devices with ZHAPower before ZHAConsumption.