### PR TITLE
Avoid incorrectly parsing waitTimeReset as bool instead of int

### DIFF
--- a/lib/DeconzPlatform.js
+++ b/lib/DeconzPlatform.js
@@ -58,7 +58,7 @@ class DeconzPlatform extends Platform {
       .intKey('waitTimePut', 0, 50)
       .intKey('waitTimePutGroup', 0, 1000)
       .intKey('waitTimeResend', 100, 1000)
-      .boolKey('waitTimeReset', 10, 2000)
+      .intKey('waitTimeReset', 10, 2000)
       .intKey('waitTimeUpdate', 0, 500)
 
     this.gatewayMap = {}


### PR DESCRIPTION
Just started reading through the code because I started using this plugin in my home. Looks like the waitTimeReset option is configured incorrectly. Maybe it is not used that much why it was not noticed earlier.